### PR TITLE
chore: add editor openers and compression via ouch

### DIFF
--- a/.config/yazi/keymap.toml
+++ b/.config/yazi/keymap.toml
@@ -12,3 +12,8 @@ desc = "Toggle preview pane"
 on = "<F4>"
 run = "plugin toggle-pane max-preview"
 desc = "Maximize / restore preview pane"
+
+[[mgr.prepend_keymap]]
+on = ["C"]
+run = "plugin ouch"
+desc = "Compress with ouch"

--- a/.config/yazi/yazi.toml
+++ b/.config/yazi/yazi.toml
@@ -9,6 +9,17 @@ image_filter = "lanczos3"
 max_width = 2048
 max_height = 2048
 
+[opener]
+edit = [
+    { run = "nvim %s", desc = "nvim", block = true },
+
+    { run = "zed %s", desc = "zed", orphan = true },
+    { run = "zed -w %s", desc = "zed (block)", block = true },
+
+    { run = "code %s", desc = "code", orphan = true },
+    { run = "code -w %s", desc = "code (block)",  block = true },
+]
+
 [[plugin.prepend_fetchers]]
 id = "git"
 url = "*"


### PR DESCRIPTION
* Configure opener entries for Neovim, Zed, and VS Code (both pieces of blocking and non-blocking modes)
* Bind `Ctrl+C` to compress selected files using the ouch plugin