### PR TITLE
feat(terminal): unify hotkeys and add ghostty config

### DIFF
--- a/dotfiles/.config/alacritty/alacritty.toml
+++ b/dotfiles/.config/alacritty/alacritty.toml
@@ -20,7 +20,7 @@ TERM = "xterm-256color"
 [window]
 decorations = "None"
 
-# Window padding in pixels
+# Window padding in pixels (unified with WezTerm/Ghostty)
 padding = { x = 5, y = 5 }
 
 # Window transparency (1.0 = fully opaque)
@@ -30,8 +30,7 @@ opacity = 0.95
 blur = true
 
 # Initial window state
-# startup_mode = "Windowed"
-startup_mode = "Maximized"
+startup_mode = "Windowed"
 
 # ==================================================
 # Scrolling behavior
@@ -44,63 +43,63 @@ history = 10000
 multiplier = 1
 
 # ==================================================
-# Font configuration
+# Font configuration (unified with WezTerm/Ghostty)
 # ==================================================
 [font]
-# normal = { family = "JetBrainsMono Nerd Font", style = "Regular" }
-# bold = { family = "JetBrainsMono Nerd Font", style = "Bold" }
-# italic = { family = "JetBrainsMono Nerd Font", style = "Italic" }
-# bold_italic = { family = "JetBrainsMono Nerd Font", style = "Bold Italic" }
+normal = { family = "IosevkaTerm Nerd Font", style = "Regular" }
+bold = { family = "IosevkaTerm Nerd Font", style = "Bold" }
+italic = { family = "IosevkaTerm Nerd Font", style = "Italic" }
+bold_italic = { family = "IosevkaTerm Nerd Font", style = "Bold Italic" }
 
-normal = { family = "CaskaydiaCove Nerd Font", style = "Regular" }
-bold = { family = "CaskaydiaCove Nerd Font", style = "Bold" }
-italic = { family = "CaskaydiaCove Nerd Font", style = "Italic" }
-bold_italic = { family = "CaskaydiaCove Nerd Font", style = "Bold Italic" }
+# Font size in points (unified)
+size = 13.0
 
-# Font size in points
-size = 14
+[font.offset]
+x = 0
+y = 0
+
+[font.glyph_offset]
+x = 0
+y = 0
 
 # ==================================================
-# Terminal / shell configuration
+# Terminal / shell configuration (unified)
 # ==================================================
 [terminal]
 # Nushell
 [terminal.shell]
 program = "nu"
-args = ["--login", "--interactive", "--execute", "z"]
-
-# # Git Bash
-# [terminal.shell]
-# program = "C:\\Program Files\\Git\\bin\\bash.exe"
-# args = ["--cd-to-home", "--login", "-i"]
-
-# # zsh
-# [terminal.shell]
-# program = "C:\\Program Files\\Git\\usr\\bin\\zsh.exe"
-# args = ["--login", "--interactive"]
-
-# # PowerShell 7
-# shell = { program = "pwsh", args = ["-NoLogo"] }
+args = ["--login", "--interactive"]
 
 # ==================================================
-# Keyboard bindings
+# Keyboard bindings (unified across terminals)
+# ==================================================
+# Rules:
+#   - Ctrl+Shift = terminal actions (no shell conflicts)
+#   - Ctrl alone = shell/TUI (SIGINT, vim, etc.)
 # ==================================================
 [keyboard]
 bindings = [
   # Toggle fullscreen mode
   { key = "F11", mods = "None", action = "ToggleFullscreen" },
+  { key = "Return", mods = "Control", action = "ToggleFullscreen" },
 
   # Open a new Alacritty window
-  { key = "T", mods = "Control", action = "CreateNewWindow" },
+  { key = "N", mods = "Control|Shift", action = "CreateNewWindow" },
 
   # Close window
-  { key = "Q", mods = "Control", action = "Quit" },
+  { key = "Q", mods = "Control|Shift", action = "Quit" },
 
-  # Copy to clipboard
-  { key = "C", mods = "Control", action = "Copy" },
+  # Copy to clipboard (Ctrl+Shift to avoid SIGINT conflict)
+  { key = "C", mods = "Control|Shift", action = "Copy" },
 
-  # Paste from clipboard
-  { key = "V", mods = "Control", action = "Paste" },
+  # Paste from clipboard (Ctrl+Shift to avoid vim conflict)
+  { key = "V", mods = "Control|Shift", action = "Paste" },
+
+  # Font size zoom
+  { key = "Plus", mods = "Control|Shift", action = "IncreaseFontSize" },
+  { key = "Minus", mods = "Control|Shift", action = "DecreaseFontSize" },
+  { key = "Key0", mods = "Control|Shift", action = "ResetFontSize" },
 ]
 
 # ==================================================

--- a/dotfiles/.config/ghostty/config
+++ b/dotfiles/.config/ghostty/config
@@ -1,0 +1,117 @@
+# =============================================================================
+# Ghostty Terminal Configuration
+# =============================================================================
+# Cross-platform terminal emulator: https://ghostty.org
+# This config follows the unified terminal parameters for this dotfiles repo.
+#
+# Font Strategy:
+#   Primary:   IosevkaTerm Nerd Font  (available in this NixOS system)
+#   Fallback:  CaskaydiaCove Nerd Font
+#   Fallback:  JetBrainsMono Nerd Font
+#
+# Unified Parameters (shared with WezTerm, Alacritty):
+#   Shell:     nu --login --interactive
+#   Padding:   5
+#   Opacity:   0.95
+#   Blur:      true
+#   Font size: 13.0
+#   Scrollback: 10000
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# Shell
+# -----------------------------------------------------------------------------
+command = nu --login --interactive
+
+# -----------------------------------------------------------------------------
+# Font
+# -----------------------------------------------------------------------------
+font-family = IosevkaTerm Nerd Font
+font-family = CaskaydiaCove Nerd Font
+font-family = JetBrainsMono Nerd Font
+font-size = 13.0
+
+# Disable ligatures for cleaner terminal text
+font-feature = -calt
+font-feature = -liga
+font-feature = -dlig
+
+# -----------------------------------------------------------------------------
+# Theme (Catppuccin with auto light/dark)
+# -----------------------------------------------------------------------------
+theme = light:Catppuccin Latte,dark:Catppuccin Mocha
+
+# -----------------------------------------------------------------------------
+# Window Appearance
+# -----------------------------------------------------------------------------
+window-padding-x = 5
+window-padding-y = 5
+window-decoration = false
+background-opacity = 0.95
+background-blur = true
+
+# -----------------------------------------------------------------------------
+# Scrollback
+# -----------------------------------------------------------------------------
+scrollback-limit = 10000
+
+# -----------------------------------------------------------------------------
+# Mouse
+# -----------------------------------------------------------------------------
+mouse-hide-while-typing = true
+mouse-scroll-multiplier = 3
+
+# -----------------------------------------------------------------------------
+# Clipboard
+# -----------------------------------------------------------------------------
+clipboard-read = allow
+clipboard-write = allow
+clipboard-trim-trailing-spaces = true
+
+# -----------------------------------------------------------------------------
+# Keybindings (unified across terminals)
+# -----------------------------------------------------------------------------
+# Rules:
+#   - Ctrl+Shift = terminal actions (no shell conflicts)
+#   - Ctrl alone = shell/TUI (SIGINT, vim, etc.)
+# -----------------------------------------------------------------------------
+
+# Tabs
+keybind = ctrl+shift+t=new_tab
+keybind = ctrl+shift+w=close_tab
+
+# Windows
+keybind = ctrl+shift+n=new_window
+keybind = ctrl+shift+q=close_window
+
+# View
+keybind = f11=toggle_fullscreen
+keybind = ctrl+enter=toggle_fullscreen
+
+# Clipboard (Ctrl+Shift to avoid shell conflicts)
+keybind = ctrl+shift+c=copy_to_clipboard
+keybind = ctrl+shift+v=paste_from_clipboard
+
+# Font size zoom
+keybind = ctrl+shift+plus=increase_font_size
+keybind = ctrl+shift+minus=decrease_font_size
+keybind = ctrl+shift+zero=reset_font_size
+
+# -----------------------------------------------------------------------------
+# Cursor
+# -----------------------------------------------------------------------------
+cursor-style = block
+cursor-style-blink = false
+cursor-click-to-move = true
+
+# -----------------------------------------------------------------------------
+# Shell Integration
+# -----------------------------------------------------------------------------
+shell-integration = detect
+shell-integration-features = cursor,sudo,title
+
+# -----------------------------------------------------------------------------
+# Performance
+# -----------------------------------------------------------------------------
+# Ghostty defaults are already well-optimized
+# No additional tweaks needed

--- a/dotfiles/.config/wezterm/wezterm.lua
+++ b/dotfiles/.config/wezterm/wezterm.lua
@@ -45,21 +45,22 @@ config.default_cwd = wezterm.home_dir
 -- Font configuration with Nerd Font fallback
 -- --------------------------------------------------
 config.font = wezterm.font_with_fallback({
-  "JetBrainsMono Nerd Font",
-  -- "JetBrains Mono",
-  -- "Symbols Nerd Font Mono",
+  { family = "IosevkaTerm Nerd Font", weight = "Medium" },
+  { family = "CaskaydiaCove Nerd Font", weight = "Medium" },
+  { family = "JetBrainsMono Nerd Font", weight = "Medium" },
+  "Noto Color Emoji",
 })
 
 config.font_size = 13.0
 
 -- --------------------------------------------------
--- Window appearance
+-- Window appearance (unified with Alacritty/Ghostty)
 -- --------------------------------------------------
 config.window_padding = {
-  left = 6,
-  right = 6,
-  top = 4,
-  bottom = 4,
+  left = 5,
+  right = 5,
+  top = 5,
+  bottom = 5,
 }
 
 -- Minimal window decorations and no tab bar
@@ -67,13 +68,16 @@ config.window_decorations = "RESIZE"
 config.enable_tab_bar = true
 config.use_fancy_tab_bar = true
 
+-- Background opacity and blur (unified)
+config.window_background_opacity = 0.95
+config.macos_window_background_blur = 20
+
 -- --------------------------------------------------
--- Key bindings
---
--- Default Key Assignments
--- wezterm show-keys --lua
---
--- https://wezterm.org/config/default-keys.html
+-- Key bindings (unified across terminals)
+-- --------------------------------------------------
+-- Rules:
+--   - Ctrl+Shift = terminal actions (no shell conflicts)
+--   - Ctrl alone = shell/TUI (SIGINT, vim, etc.)
 -- --------------------------------------------------
 config.keys = {
   -- New tab
@@ -83,17 +87,67 @@ config.keys = {
     action = wezterm.action.SpawnTab("CurrentPaneDomain"),
   },
 
-  -- Close tab fast
+  -- Close tab
   {
     key = "W",
     mods = "CTRL|SHIFT",
     action = wezterm.action.CloseCurrentTab({ confirm = false }),
   },
 
+  -- New window
+  {
+    key = "N",
+    mods = "CTRL|SHIFT",
+    action = wezterm.action.SpawnWindow,
+  },
+
+  -- Close window
+  {
+    key = "Q",
+    mods = "CTRL|SHIFT",
+    action = wezterm.action.QuitApplication,
+  },
+
   -- Toggle fullscreen
   {
     key = "F11",
     action = wezterm.action.ToggleFullScreen,
+  },
+  {
+    key = "Enter",
+    mods = "CTRL",
+    action = wezterm.action.ToggleFullScreen,
+  },
+
+  -- Copy (Ctrl+Shift to avoid SIGINT conflict)
+  {
+    key = "C",
+    mods = "CTRL|SHIFT",
+    action = wezterm.action.CopyTo("Clipboard"),
+  },
+
+  -- Paste (Ctrl+Shift to avoid vim conflict)
+  {
+    key = "V",
+    mods = "CTRL|SHIFT",
+    action = wezterm.action.PasteFrom("Clipboard"),
+  },
+
+  -- Font size zoom
+  {
+    key = "Equal",
+    mods = "CTRL|SHIFT",
+    action = wezterm.action.IncreaseFontSize,
+  },
+  {
+    key = "Minus",
+    mods = "CTRL|SHIFT",
+    action = wezterm.action.DecreaseFontSize,
+  },
+  {
+    key = "0",
+    mods = "CTRL|SHIFT",
+    action = wezterm.action.ResetFontSize,
   },
 }
 

--- a/nixos/home.nix
+++ b/nixos/home.nix
@@ -7,9 +7,12 @@
 let
   link = config.lib.file.mkOutOfStoreSymlink;
   dotfileLinks = [
+    ".bash_profile"
+    ".bashrc"
     ".config/alacritty"
     ".config/bash"
     ".config/fastfetch"
+    ".config/ghostty"
     ".config/git"
     ".config/lazygit"
     ".config/nushell"

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -7,43 +7,43 @@ directories:
       tags:
       - yaml-68-g2749b40
     path: .
-  path: dotfiles\.config\alacritty\themes\themes
+  path: dotfiles/.config/alacritty/themes/themes
 - contents:
   - git:
       commitTitle: 'ci: bump dessant/lock-threads from 5 to 6 (#76)'
       sha: 36c49acfd7d3924bd751fd74e37b6ff438af691a
     path: .
-  path: dotfiles\.config\yazi\flavors\catppuccin-latte.yazi
+  path: dotfiles/.config/yazi/flavors/catppuccin-latte.yazi
 - contents:
   - git:
       commitTitle: 'ci: bump dessant/lock-threads from 5 to 6 (#76)'
       sha: 36c49acfd7d3924bd751fd74e37b6ff438af691a
     path: .
-  path: dotfiles\.config\yazi\flavors\catppuccin-mocha.yazi
+  path: dotfiles/.config/yazi/flavors/catppuccin-mocha.yazi
 - contents:
   - git:
       commitTitle: 'ci: bump dessant/lock-threads from 5 to 6 (#211)'
       sha: be524fb140206cc59b3e51037ba6148935263975
     path: .
-  path: dotfiles\.config\yazi\plugins\chmod.yazi
+  path: dotfiles/.config/yazi/plugins/chmod.yazi
 - contents:
   - git:
       commitTitle: manager -> mgr api fix
       sha: 71545f4ee1a0896c555b3118dc3d2b0a1b92fad9
     path: .
-  path: dotfiles\.config\yazi\plugins\copy-file-contents.yazi
+  path: dotfiles/.config/yazi/plugins/copy-file-contents.yazi
 - contents:
   - git:
       commitTitle: 'ci: bump dessant/lock-threads from 5 to 6 (#211)'
       sha: be524fb140206cc59b3e51037ba6148935263975
     path: .
-  path: dotfiles\.config\yazi\plugins\full-border.yazi
+  path: dotfiles/.config/yazi/plugins/full-border.yazi
 - contents:
   - git:
       commitTitle: 'ci: bump dessant/lock-threads from 5 to 6 (#211)'
       sha: be524fb140206cc59b3e51037ba6148935263975
     path: .
-  path: dotfiles\.config\yazi\plugins\git.yazi
+  path: dotfiles/.config/yazi/plugins/git.yazi
 - contents:
   - git:
       commitTitle: 'Merge pull request #35 from openaitx-system/Auto_translate_README_and_Wiki...'
@@ -51,31 +51,31 @@ directories:
       tags:
       - v0.7.0-12-g406ce6c
     path: .
-  path: dotfiles\.config\yazi\plugins\ouch.yazi
+  path: dotfiles/.config/yazi/plugins/ouch.yazi
 - contents:
   - git:
       commitTitle: 'ci: bump dessant/lock-threads from 5 to 6 (#211)'
       sha: be524fb140206cc59b3e51037ba6148935263975
     path: .
-  path: dotfiles\.config\yazi\plugins\piper.yazi
+  path: dotfiles/.config/yazi/plugins/piper.yazi
 - contents:
   - git:
       commitTitle: 'docs(readme): update thanks section'
       sha: a83710153ab5625a64ef98d55e6ddad480a3756f
     path: .
-  path: dotfiles\.config\yazi\plugins\starship.yazi
+  path: dotfiles/.config/yazi/plugins/starship.yazi
 - contents:
   - git:
       commitTitle: 'ci: bump dessant/lock-threads from 5 to 6 (#211)'
       sha: be524fb140206cc59b3e51037ba6148935263975
     path: .
-  path: dotfiles\.config\yazi\plugins\toggle-pane.yazi
+  path: dotfiles/.config/yazi/plugins/toggle-pane.yazi
 - contents:
   - git:
       commitTitle: 'fix(deprecated): use Command:arg() instead of Command:args()'
       sha: f46528243c458de3ffce38c44607d5a0cde67559
     path: .
-  path: dotfiles\.config\yazi\plugins\torrent-preview.yazi
+  path: dotfiles/.config/yazi/plugins/torrent-preview.yazi
 - contents:
   - git:
       commitTitle: 'chore(v26.5.6): `size` => `length`'
@@ -83,5 +83,5 @@ directories:
       tags:
       - v2.5.4
     path: .
-  path: dotfiles\.config\yazi\plugins\yaziline.yazi
+  path: dotfiles/.config/yazi/plugins/yaziline.yazi
 kind: LockConfig


### PR DESCRIPTION
Unify keyboard shortcuts across Alacritty, WezTerm, and Ghostty:
- Ctrl+Shift for terminal actions (no shell conflicts)
- Ctrl alone reserved for shell/TUI (SIGINT, vim, etc.)
- Add Ctrl+Enter as secondary fullscreen toggle
- Add font zoom keys (Ctrl+Shift+Plus/Minus/0)
- Fix Copy/Paste to use Ctrl+Shift (avoids SIGINT/vim conflicts)

Add Ghostty terminal config with Catppuccin theme support.

Update nixos/home.nix to include ghostty, bash_profile, bashrc.
