### PR TITLE
feat(ci): extend Lua validation, add WezTerm/Git/PowerShell verification

### DIFF
--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -1,0 +1,33 @@
+name: Daily Cache Cleanup
+
+on:
+  schedule:
+    - cron: "50 1 * * *" # Daily at 01:50 UTC
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read # Default read-only for all jobs
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  clear:
+    name: Clear Caches
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    permissions:
+      actions: write # Required to list and delete GitHub Actions caches.
+
+    steps:
+      - name: Clear all caches
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: gh cache delete --all --repo "$REPO"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,13 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read # Default read-only for all jobs
+
+env:
+  NIXPKGS: github:NixOS/nixpkgs/nixos-unstable
 
 defaults:
   run:
@@ -31,18 +34,47 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           persist-credentials: false
 
-      - name: Setup Just
-        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
+      - name: Install Nix
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
 
-      - name: Source Format Check
-        uses: dprint/check@9cb3a2b17a8e606d37aae341e49df3654933fc23 # v2.3
+      - name: Restore and save Nix store
+        uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7
+        with:
+          primary-key: nix-${{ runner.os }}-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}-
+          gc-max-store-size-linux: 1G
+          purge: true
+          purge-prefixes: nix-${{ runner.os }}-${{ github.job }}-
+          purge-created: 0
+          purge-last-accessed: P1DT12H
+          purge-primary-key: never
 
-      - name: Justfile Format Check
-        run: just --fmt --check
+      - name: Download tools
+        run: nix shell "$NIXPKGS#just" "$NIXPKGS#dprint" "$NIXPKGS#stylua" "$NIXPKGS#shfmt" --command true
+
+      - name: Check Justfile formatting
+        run: nix shell "$NIXPKGS#just" --command just --fmt --check
+
+      - name: Format Check
+        run: nix shell "$NIXPKGS#dprint" --command dprint check
+
+      - name: Check Lua formatting
+        run: nix shell "$NIXPKGS#stylua" --command stylua --allow-hidden --check .
+
+      - name: Check shell formatting
+        run: |
+          # shellcheck disable=SC2016
+          nix shell "$NIXPKGS#shfmt" --command bash -euo pipefail -c '
+            shell_targets="dotfiles/.bashrc dotfiles/.bash_profile dotfiles/.config/bash dotfiles/.config/shell"
+            shfmt --diff $(shfmt --find $shell_targets)
+          '
 
   # ---------------------------------------------------------------------------
   # Stage 1: Lint Quality Gate
@@ -54,30 +86,91 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           persist-credentials: false
 
-      - name: YAML Lint
-        uses: ibiqlik/action-yamllint@2576378a8e339169678f9939646ee3ee325e845c # v3.1.1
-
-      - name: Setup Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      - name: Install Nix
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31
         with:
-          go-version: stable
-          cache: false
+          extra_nix_config: |
+            experimental-features = nix-command flakes
 
-      - name: Install actionlint
-        run: go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
+      - name: Restore and save Nix store
+        uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7
+        with:
+          primary-key: nix-${{ runner.os }}-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}-
+          gc-max-store-size-linux: 1G
+          purge: true
+          purge-prefixes: nix-${{ runner.os }}-${{ github.job }}-
+          purge-created: 0
+          purge-last-accessed: P1DT12H
+          purge-primary-key: never
 
-      - name: ActionLint
-        run: actionlint
+      - name: Download tools
+        run: |
+          nix shell \
+            "$NIXPKGS#yamllint" \
+            "$NIXPKGS#actionlint" \
+            "$NIXPKGS#shellcheck" \
+            "$NIXPKGS#shfmt" \
+            "$NIXPKGS#selene" \
+            "$NIXPKGS#taplo" \
+            "$NIXPKGS#zellij" \
+            "$NIXPKGS#nushell" \
+            "$NIXPKGS#markdownlint-cli2" \
+            --command true
+
+      - name: Lint YAML
+        run: nix shell "$NIXPKGS#yamllint" --command yamllint .
+
+      - name: Lint GitHub Actions
+        run: nix shell "$NIXPKGS#actionlint" --command actionlint
+
+      - name: Lint shell scripts
+        run: |
+          # shellcheck disable=SC2016
+          nix shell "$NIXPKGS#shellcheck" "$NIXPKGS#shfmt" --command bash -euo pipefail -c '
+            shell_targets="dotfiles/.bashrc dotfiles/.bash_profile dotfiles/.config/bash dotfiles/.config/shell"
+            shellcheck -s bash $(shfmt --find $shell_targets)
+          '
+
+      - name: Lint Lua
+        run: |
+          # shellcheck disable=SC2016
+          nix shell "$NIXPKGS#selene" --command bash -euo pipefail -c '
+            selene dotfiles/.config/nvim dotfiles/.config/wezterm
+            selene --config dotfiles/.config/hypr/selene.toml dotfiles/.config/hypr/hyprland.lua
+          '
+
+      - name: Lint TOML
+        run: |
+          # shellcheck disable=SC2016
+          nix shell "$NIXPKGS#taplo" --command bash -euo pipefail -c '
+            taplo lint --no-schema \
+              $(find dotfiles/.config -type f -name "*.toml" \
+                ! -path "*/node_modules/*" \
+                ! -path "*/yazi/plugins/*" \
+                ! -path "*/alacritty/themes/*")
+          '
+
+      - name: Lint Markdown
+        run: nix shell "$NIXPKGS#markdownlint-cli2" --command markdownlint-cli2
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
       - name: Lint CSS
         run: bunx stylelint@16 --config .stylelintrc.json './dotfiles/.config/**/*.css'
+
+      - name: Validate Zellij config
+        run: |
+          nix shell "$NIXPKGS#zellij" --command zellij --config "$PWD/dotfiles/.config/zellij/config.kdl" setup --dump-config >/dev/null
+
+      - name: Validate Nushell config
+        run: |
+          nix shell "$NIXPKGS#nushell" --command nu --config dotfiles/.config/nushell/config.nu --env-config dotfiles/.config/nushell/env.nu -c "exit 0"
 
   # ---------------------------------------------------------------------------
   # Stage 1: Security
@@ -93,7 +186,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -144,26 +237,48 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           persist-credentials: false
 
-      - name: Install ClamAV
-        run: |
-          sudo apt-get update
-          sudo apt-get install --yes clamav
+      - name: Install Nix
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
 
-      - name: Prepare freshclam
-        run: |
-          sudo systemctl stop clamav-freshclam 2>/dev/null || true
-          sudo pkill -f freshclam 2>/dev/null || true
-          sudo rm -f /var/log/clamav/freshclam.log
+      - name: Restore and save Nix store
+        uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7
+        with:
+          primary-key: nix-${{ runner.os }}-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}-
+          gc-max-store-size-linux: 1G
+          purge: true
+          purge-prefixes: nix-${{ runner.os }}-${{ github.job }}-
+          purge-created: 0
+          purge-last-accessed: P1DT12H
+          purge-primary-key: never
 
-      - name: Update virus database
-        run: sudo freshclam
+      - name: Download tools
+        run: nix shell "$NIXPKGS#clamav" --command true
+
+      - name: Download ClamAV database
+        run: |
+          db_dir="$(mktemp -d)"
+          config_file="$(mktemp)"
+          printf '%s\n' \
+            "DatabaseDirectory $db_dir" \
+            "DatabaseMirror database.clamav.net" \
+            >"$config_file"
+          echo "CLAMAV_DB_DIR=$db_dir" >> "$GITHUB_ENV"
+          nix shell "$NIXPKGS#clamav" --command freshclam --config-file="$config_file"
+        env:
+          LANG: C.UTF-8
 
       - name: Scan for malware
-        run: clamscan -r --infected .
+        run: nix shell "$NIXPKGS#clamav" --command clamscan --database="$CLAMAV_DB_DIR" -r --infected .
+        env:
+          LANG: C.UTF-8
 
   # ---------------------------------------------------------------------------
   # Stage 1: Documentation Gate
@@ -175,15 +290,33 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           persist-credentials: false
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Restore and save Nix store
+        uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7
+        with:
+          primary-key: nix-${{ runner.os }}-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}-
+          gc-max-store-size-linux: 1G
+          purge: true
+          purge-prefixes: nix-${{ runner.os }}-${{ github.job }}-
+          purge-created: 0
+          purge-last-accessed: P1DT12H
+          purge-primary-key: never
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
       - name: Restore Bun cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ hashFiles('docs/bun.lock') }}
@@ -202,18 +335,15 @@ jobs:
         working-directory: docs
         run: bun run docs:build
 
-      - name: Install Lychee
-        uses: jaxxstorm/action-install-gh-release@25e24d2d23ae098373794ef1d6faecb48ee52da8 # v3.0.0
-        with:
-          repo: lycheeverse/lychee
-          tag: lychee-v0.24.2
-          digest: 1f4e0ef7f6554a6ed33dd7ac144fb2e1bbed98598e7af973042fc5cd43951c9a
-          platform: linux
-          arch: x86_64
+      - name: Download tools
+        run: nix shell "$NIXPKGS#lychee" --command true
 
       - name: Link Check
-        run: >-
-          lychee --config .lychee.toml --root-dir "$GITHUB_WORKSPACE/docs/.vitepress/dist" docs/.vitepress/dist
+        run: |
+          # shellcheck disable=SC2016
+          nix shell "$NIXPKGS#lychee" --command bash -euo pipefail -c '
+            lychee --config .lychee.toml --root-dir "$GITHUB_WORKSPACE/docs/.vitepress/dist" docs/.vitepress/dist
+          '
 
       - name: Upload GitHub Pages artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
@@ -222,363 +352,128 @@ jobs:
           path: docs/.vitepress/dist
 
   # ---------------------------------------------------------------------------
-  # Stage 2: Hyprland
+  # Stage 2: Verify application configs (one matrix entry per app)
   # ---------------------------------------------------------------------------
-  hyprland:
-    name: Hyprland
+  verify:
+    name: ${{ matrix.name }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     needs: [fmt, lint, security, antivirus, docs]
 
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Window manager
+          - name: Hyprland
+            app: hyprland
+            deps: 'nix profile install "$NIXPKGS#just" "$NIXPKGS#hyprland"'
+
+          # Editors
+          - name: Helix
+            app: helix
+            deps: 'nix profile install "$NIXPKGS#just" "$NIXPKGS#helix"'
+
+          - name: Neovim
+            app: neovim
+            deps: 'nix profile install "$NIXPKGS#just" "$NIXPKGS#neovim" "$NIXPKGS#lua5_1" "$NIXPKGS#git"'
+
+          # Terminals
+          - name: Alacritty
+            app: alacritty
+            deps: 'nix profile install "$NIXPKGS#just" "$NIXPKGS#alacritty" "$NIXPKGS#vendir"'
+
+          - name: Ghostty
+            app: ghostty
+            deps: 'nix profile install "$NIXPKGS#just" "$NIXPKGS#ghostty"'
+
+          - name: WezTerm
+            app: wezterm
+            deps: 'nix profile install "$NIXPKGS#just" "$NIXPKGS#wezterm"'
+
+          # Shells
+          - name: Bash
+            app: bash
+            deps: 'nix profile install "$NIXPKGS#just"'
+
+          - name: Nushell
+            app: nushell
+            deps: 'nix profile install "$NIXPKGS#just" "$NIXPKGS#nushell"'
+
+          - name: PowerShell
+            app: powershell
+            deps: 'nix profile install "$NIXPKGS#just" "$NIXPKGS#powershell"'
+
+          - name: Zsh
+            app: zsh
+            deps: 'nix profile install "$NIXPKGS#just" "$NIXPKGS#zsh"'
+
+          # Shell tooling (prompt, multiplexer, file manager)
+          - name: Starship
+            app: starship
+            deps: 'nix profile install "$NIXPKGS#just" "$NIXPKGS#starship"'
+
+          - name: Yazi
+            app: yazi
+            deps: 'nix profile install "$NIXPKGS#just" "$NIXPKGS#yazi" "$NIXPKGS#vendir"'
+
+          - name: Zellij
+            app: zellij
+            deps: 'nix profile install "$NIXPKGS#just" "$NIXPKGS#zellij"'
+
+          # Dotfiles management
+          - name: Stow
+            app: stow
+            deps: 'nix profile install "$NIXPKGS#just" "$NIXPKGS#stow" "$NIXPKGS#vendir"'
+
+          # Version control
+          - name: Git
+            app: git
+            deps: 'nix profile install "$NIXPKGS#just" "$NIXPKGS#git"'
+
+          # Coding agents
+          - name: Kimi
+            app: kimi
+            deps: 'nix profile install "$NIXPKGS#just" && npm install -g @moonshot-ai/kimi-code@latest'
+
+          - name: OpenCode
+            app: opencode
+            deps: 'nix profile install "$NIXPKGS#just" && npm install -g opencode-ai@latest'
+
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           persist-credentials: false
 
       - name: Install Nix
         uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31
-
-      - name: Verify Hyprland config
-        run: nix shell nixpkgs#hyprland --command hyprland --verify-config -c "$PWD/dotfiles/.config/hypr/hyprland.lua"
-
-  # ---------------------------------------------------------------------------
-  # Stage 2: Neovim
-  # ---------------------------------------------------------------------------
-  neovim:
-    name: Neovim
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    needs: [fmt, lint, security, antivirus, docs]
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          persist-credentials: false
+          extra_nix_config: |
+            experimental-features = nix-command flakes
 
-      - name: Install Nix
-        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31
-
-      - name: Validate Neovim config
-        run: |
-          tmp_home="$(mktemp -d)"
-          mkdir -p "$tmp_home/.config"
-          ln -s "$PWD/dotfiles/.config/nvim" "$tmp_home/.config/nvim"
-
-          HOME="$tmp_home" nix shell nixpkgs#lua5_1 --command \
-            luac -p "$tmp_home/.config/nvim/init.lua"
-
-          # shellcheck disable=SC2016
-          nix shell nixpkgs#neovim nixpkgs#git --command \
-            bash -euo pipefail -c '
-              export HOME="$1"
-              export XDG_CONFIG_HOME="$HOME/.config"
-              export XDG_DATA_HOME="$HOME/.local/share"
-              export XDG_STATE_HOME="$HOME/.local/state"
-              export XDG_CACHE_HOME="$HOME/.cache"
-
-              nvim --headless "+Lazy! sync" +qa
-              nvim_output="$(mktemp)"
-              nvim --headless +qa >"$nvim_output" 2>&1
-              if [ -s "$nvim_output" ]; then
-                cat "$nvim_output"
-                exit 1
-              fi
-            ' bash "$tmp_home"
-
-  # ---------------------------------------------------------------------------
-  # Stage 2: Helix
-  # ---------------------------------------------------------------------------
-  helix:
-    name: Helix
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    needs: [fmt, lint, security, antivirus, docs]
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Restore and save Nix store
+        uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7
         with:
-          persist-credentials: false
+          primary-key: nix-${{ runner.os }}-${{ github.job }}-${{ matrix.app }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}-${{ matrix.app }}-
+          gc-max-store-size-linux: 1G
+          purge: true
+          purge-prefixes: nix-${{ runner.os }}-${{ github.job }}-${{ matrix.app }}-
+          purge-created: 0
+          purge-last-accessed: P1DT12H
+          purge-primary-key: never
 
-      - name: Install Nix
-        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31
-
-      - name: Validate Helix config
-        run: |
-          tmp_home="$(mktemp -d)"
-          mkdir -p "$tmp_home/.config"
-          ln -s "$PWD/dotfiles/.config/helix" "$tmp_home/.config/helix"
-
-          HOME="$tmp_home" XDG_CONFIG_HOME="$tmp_home/.config" \
-            nix shell nixpkgs#helix --command hx --health all
-
-  # ---------------------------------------------------------------------------
-  # Stage 2: Ghostty
-  # ---------------------------------------------------------------------------
-  ghostty:
-    name: Ghostty
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    needs: [fmt, lint, security, antivirus, docs]
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          persist-credentials: false
+          node-version: 22
 
-      - name: Install Nix
-        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31
+      - name: Install ${{ matrix.name }} dependencies
+        run: ${{ matrix.deps }}
 
-      - name: Validate Ghostty config
-        run: nix shell nixpkgs#ghostty --command ghostty +validate-config --config-file="$PWD/dotfiles/.config/ghostty/config"
-
-  # ---------------------------------------------------------------------------
-  # Stage 2: Alacritty
-  # ---------------------------------------------------------------------------
-  alacritty:
-    name: Alacritty
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    needs: [fmt, lint, security, antivirus, docs]
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          persist-credentials: false
-
-      - name: Install Nix
-        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31
-
-      - name: Setup Vendir
-        uses: carvel-dev/setup-action@efbf2625e8469080d87175c02690634d4b0ad476 # v2.2.0
-        with:
-          only: vendir
-          token: ${{ github.token }}
-
-      - name: Sync dependencies
-        run: vendir sync
-
-      - name: Validate Alacritty config
-        run: |
-          tmp_home="$(mktemp -d)"
-          mkdir -p "$tmp_home/.config"
-          ln -s "$PWD/dotfiles/.config/alacritty" "$tmp_home/.config/alacritty"
-
-          HOME="$tmp_home" nix shell nixpkgs#alacritty --command \
-            alacritty migrate --dry-run --config-file "$tmp_home/.config/alacritty/alacritty.toml" >/dev/null
-
-  # ---------------------------------------------------------------------------
-  # Stage 2: Nushell
-  # ---------------------------------------------------------------------------
-  nushell:
-    name: Nushell
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    needs: [fmt, lint, security, antivirus, docs]
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          persist-credentials: false
-
-      - name: Install Nix
-        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31
-
-      - name: Validate Nushell config
-        run: |
-          nix shell nixpkgs#nushell --command \
-            nu --config dotfiles/.config/nushell/config.nu \
-              --env-config dotfiles/.config/nushell/env.nu \
-              -c "exit 0"
-
-  # ---------------------------------------------------------------------------
-  # Stage 2: Yazi
-  # ---------------------------------------------------------------------------
-  yazi:
-    name: Yazi
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    needs: [fmt, lint, security, antivirus, docs]
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          persist-credentials: false
-
-      - name: Install Yazi
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh release download --repo sxyazi/yazi --pattern 'yazi-x86_64-unknown-linux-gnu.zip'
-          unzip -q yazi-x86_64-unknown-linux-gnu.zip
-          sudo mv yazi-x86_64-unknown-linux-gnu/yazi /usr/local/bin/
-          sudo mv yazi-x86_64-unknown-linux-gnu/ya /usr/local/bin/
-
-      - name: Setup Vendir
-        uses: carvel-dev/setup-action@efbf2625e8469080d87175c02690634d4b0ad476 # v2.2.0
-        with:
-          only: vendir
-          token: ${{ github.token }}
-
-      - name: Sync dependencies
-        run: vendir sync
-
-      - name: Validate Yazi config
-        run: YAZI_CONFIG_HOME="$PWD/dotfiles/.config/yazi" yazi --debug
-
-  # ---------------------------------------------------------------------------
-  # Stage 2: Starship
-  # ---------------------------------------------------------------------------
-  starship:
-    name: Starship
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    needs: [fmt, lint, security, antivirus, docs]
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          persist-credentials: false
-
-      - name: Install Starship
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh release download --repo starship/starship --pattern 'starship-x86_64-unknown-linux-gnu.tar.gz'
-          tar -xzf starship-x86_64-unknown-linux-gnu.tar.gz
-          sudo mv starship /usr/local/bin/
-
-      - name: Validate Starship configs
-        run: |
-          STARSHIP_CONFIG="$PWD/dotfiles/.config/starship/starship.toml" starship print-config >/dev/null
-          STARSHIP_CONFIG="$PWD/dotfiles/.config/starship/starship.tmux.toml" starship print-config >/dev/null
-          STARSHIP_CONFIG="$PWD/dotfiles/.config/starship/starship.zellij.toml" starship print-config >/dev/null
-
-  # ---------------------------------------------------------------------------
-  # Stage 2: Zellij
-  # ---------------------------------------------------------------------------
-  zellij:
-    name: Zellij
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    needs: [fmt, lint, security, antivirus, docs]
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          persist-credentials: false
-
-      - name: Install Zellij
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh release download --repo zellij-org/zellij --pattern 'zellij-x86_64-unknown-linux-musl.tar.gz'
-          tar -xzf zellij-x86_64-unknown-linux-musl.tar.gz
-          sudo mv zellij /usr/local/bin/
-
-      - name: Validate Zellij config
-        run: zellij --config "$PWD/dotfiles/.config/zellij/config.kdl" setup --dump-config >/dev/null
-
-  # ---------------------------------------------------------------------------
-  # Stage 2: Bash
-  # ---------------------------------------------------------------------------
-  bash:
-    name: Bash
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    needs: [fmt, lint, security, antivirus, docs]
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          persist-credentials: false
-
-      - name: Validate Bash config
-        run: |
-          bash -n dotfiles/.bashrc dotfiles/.bash_profile
-          bash -n dotfiles/.config/bash/bashrc dotfiles/.config/bash/bash_profile
-          bash -n dotfiles/.config/bash/bash.d/*.bash
-          bash -n dotfiles/.config/shell/shell.d/*.sh dotfiles/.config/shell/profile.d/*.sh
-
-  # ---------------------------------------------------------------------------
-  # Stage 2: Zsh
-  # ---------------------------------------------------------------------------
-  zsh:
-    name: Zsh
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    needs: [fmt, lint, security, antivirus, docs]
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          persist-credentials: false
-
-      - name: Validate Zsh config
-        shell: bash
-        run: |
-          sudo apt-get update
-          sudo apt-get install --yes zsh
-
-          zsh -n dotfiles/.config/zsh/.zshrc
-          zsh -n dotfiles/.config/zsh/.zprofile
-          zsh -n dotfiles/.config/zsh/zsh.d/*.zsh
-
-  # ---------------------------------------------------------------------------
-  # Stage 2: Stow
-  # ---------------------------------------------------------------------------
-  stow:
-    name: Stow
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    needs: [fmt, lint, security, antivirus, docs]
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          persist-credentials: false
-
-      - name: Install stow
-        run: |
-          sudo apt-get update
-          sudo apt-get install --yes stow
-
-      - name: Setup Vendir
-        uses: carvel-dev/setup-action@efbf2625e8469080d87175c02690634d4b0ad476 # v2.2.0
-        with:
-          only: vendir
-          token: ${{ github.token }}
-
-      - name: Sync dependencies
-        run: vendir sync
-
-      - name: Link dotfiles
-        run: |
-          rm -f "$HOME/.bashrc" "$HOME/.bash_profile"
-          stow -v --target="${HOME}" dotfiles
-
-      - name: Verify symlinks
-        run: |
-          test -L "$HOME/.bashrc"
-          test -L "$HOME/.config/nvim"
-          test -L "$HOME/.config/helix"
-          test -L "$HOME/.config/nushell"
-          test -L "$HOME/.config/starship"
-          test -L "$HOME/.config/zellij"
-          test -L "$HOME/.config/yazi"
-          test -L "$HOME/.config/ghostty"
-          test -L "$HOME/.config/zsh"
+      - name: Verify ${{ matrix.name }} config
+        run: just verify ${{ matrix.app }}
 
   # ---------------------------------------------------------------------------
   # Stage 3: Deploy to GitHub Pages (main only)
@@ -594,20 +489,8 @@ jobs:
       - lint
       - antivirus
       - security
-
-      - alacritty
-      - bash
       - docs
-      - ghostty
-      - helix
-      - hyprland
-      - neovim
-      - nushell
-      - starship
-      - stow
-      - yazi
-      - zellij
-      - zsh
+      - verify
 
     permissions:
       pages: write

--- a/Justfile
+++ b/Justfile
@@ -61,19 +61,18 @@ uninstall:
 # Development
 # ==============================================================================
 
-[doc('Install dependencies')]
+[doc('Show how to enter the Nix dev shell')]
 [group('Development')]
 deps:
-    @echo "🔧 Installing tools..."
-    go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
-    @echo "✅ Dependencies installed!"
+    @echo "🔧 All CI/dev tools are provided by the Nix flake."
+    @echo "   Run: nix develop"
 
 [doc('Format code')]
 [group('Development')]
 fmt:
     @echo "✨ Formatting code..."
     dprint fmt
-    stylua .
+    stylua --allow-hidden .
     shfmt --write {{ SHELL_TARGETS }}
     just --fmt
     @echo "✅ Code formatted!"
@@ -82,13 +81,17 @@ fmt:
 [group('Development')]
 lint:
     @echo "🔍 Running linters..."
-    selene dotfiles/.config/nvim
+    selene dotfiles/.config/nvim dotfiles/.config/wezterm
+    selene --config dotfiles/.config/hypr/selene.toml dotfiles/.config/hypr/hyprland.lua
     shellcheck -s bash $(shfmt --find {{ SHELL_TARGETS }})
     yamllint .
     markdownlint-cli2
     actionlint
-    bunx stylelint@16 --config .stylelintrc.json './dotfiles/.config/**/*.css'
+    stylelint --config .stylelintrc.json './dotfiles/.config/**/*.css'
     @echo "✅ Linting complete!"
+
+[group: 'Development']
+mod verify 'misc/justfiles/verify.just'
 
 # ==============================================================================
 # Documentation

--- a/dotfiles/.config/bash/bash.d/50-completion.bash
+++ b/dotfiles/.config/bash/bash.d/50-completion.bash
@@ -24,7 +24,9 @@ fi
 # Load System Completion
 # -------------------------------------------------------------------
 if [[ -f /usr/share/bash-completion/bash_completion ]]; then
+  # shellcheck source=/dev/null
   source /usr/share/bash-completion/bash_completion
 elif [[ -f /etc/bash_completion ]]; then
+  # shellcheck source=/dev/null
   source /etc/bash_completion
 fi

--- a/dotfiles/.config/bash/bash.d/90-tools.bash
+++ b/dotfiles/.config/bash/bash.d/90-tools.bash
@@ -30,6 +30,7 @@ _bash_eval_cache() {
   if [ ! -f "$cache_file" ] || [ "$bin_path" -nt "$cache_file" ]; then
     eval "$cmd_exec" >"$cache_file"
   fi
+  # shellcheck source=/dev/null
   source "$cache_file"
 }
 

--- a/dotfiles/.config/hypr/selene.toml
+++ b/dotfiles/.config/hypr/selene.toml
@@ -1,0 +1,7 @@
+# Hyprland evaluates this config with an injected global `hl` (the Hyprland Lua
+# API), so the undefined-variable lint is disabled here. Syntax and the other
+# selene lints still apply. Used via: selene --config <this> hyprland.lua
+std = "lua51"
+
+[lints]
+undefined_variable = "allow"

--- a/dotfiles/.config/shell/shell.d/20-theme.sh
+++ b/dotfiles/.config/shell/shell.d/20-theme.sh
@@ -116,7 +116,7 @@ apply_theme() {
     # Convert path to Unix-style for TOML (works on all platforms)
     local ALACRITTY_THEME_PATH="$ALACRITTY_THEME_DIR/themes/$ALACRITTY_THEME"
     local ALACRITTY_THEME_PATH_UNIX
-    ALACRITTY_THEME_PATH_UNIX=$(echo "$ALACRITTY_THEME_PATH" | sed 's|\\|/|g')
+    ALACRITTY_THEME_PATH_UNIX="${ALACRITTY_THEME_PATH//\\//}"
 
     # Generate theme.toml only if needed (saves IO)
     if [ ! -f "$ALACRITTY_THEME_FILE" ] || ! grep -q "$ALACRITTY_THEME" "$ALACRITTY_THEME_FILE"; then

--- a/dotfiles/.config/shell/shell.d/40-functions.sh
+++ b/dotfiles/.config/shell/shell.d/40-functions.sh
@@ -40,7 +40,7 @@ if ! command -v take >/dev/null 2>&1; then
       esac
       mkdir -p "$dir" && cd "$dir" || return 1
     done
-    printf "\033[0;32m📂 Entered: \033[1;32m$PWD\033[0m\n"
+    printf "\033[0;32m📂 Entered: \033[1;32m%s\033[0m\n" "$PWD"
   }
 fi
 
@@ -73,7 +73,13 @@ bak() {
 # Usage: unbak <filename>
 unbak() {
   [ -z "$1" ] && return 1
-  latest=$(ls -t "${1}.bak."* 2>/dev/null | head -1)
+  latest=""
+  for f in "${1}.bak."*; do
+    [ -e "$f" ] || continue
+    if [ -z "$latest" ] || [ "$f" -nt "$latest" ]; then
+      latest="$f"
+    fi
+  done
   [ -n "$latest" ] && cp -r "$latest" "$1" && echo "♻️  Restored from: $latest"
 }
 
@@ -118,7 +124,11 @@ pconv() {
     return 1
   }
   if command -v cygpath >/dev/null 2>&1; then
-    [[ "$1" == [A-Za-z]:* ]] || [[ "$1" == *\\* ]] && cygpath -u "$1" || cygpath -w "$1"
+    if [[ "$1" == [A-Za-z]:* ]] || [[ "$1" == *\\* ]]; then
+      cygpath -u "$1"
+    else
+      cygpath -w "$1"
+    fi
   else
     case "$1" in
     [A-Za-z]:*) echo "$1" | sed -E 's|^([A-Za-z]):|/\L\1|; s|\\|/|g' ;;
@@ -182,11 +192,13 @@ note() {
     echo "" >>"$note_file"
   fi
 
-  echo "### $(date '+%H:%M:%S')" >>"$note_file"
-  echo "$*" >>"$note_file"
-  echo "" >>"$note_file"
+  {
+    echo "### $(date '+%H:%M:%S')"
+    echo "$*"
+    echo ""
+  } >>"$note_file"
 
-  printf "\033[0;32m📝 Note added to: \033[1;32m$note_file\033[0m\n"
+  printf "\033[0;32m📝 Note added to: \033[1;32m%s\033[0m\n" "$note_file"
 }
 
 # ==============================================

--- a/dotfiles/.config/shell/shell.d/43-net.sh
+++ b/dotfiles/.config/shell/shell.d/43-net.sh
@@ -27,7 +27,7 @@ weather() {
     printf "\033[0;31m❌ Invalid city name\033[0m\n"
     return 1
   fi
-  printf "\033[0;36m🌤️  Fetching weather for: \033[1;36m$city\033[0m\n"
+  printf "\033[0;36m🌤️  Fetching weather for: \033[1;36m%s\033[0m\n" "$city"
   curl -fsSL "https://wttr.in/$(printf '%s\n' "$city" | sed 's/ /+/g')"
 }
 
@@ -70,7 +70,7 @@ download() {
   local filename
   filename=$(basename "$url")
 
-  printf "\033[0;34m⬇️  Downloading \033[1;34m$filename\033[0m...\n"
+  printf "\033[0;34m⬇️  Downloading \033[1;34m%s\033[0m...\n" "$filename"
   if command -v curl >/dev/null 2>&1; then
     if ! curl -fsSL "$url" -o "$tmp_dir/$filename"; then
       printf "\033[0;31m❌ Download failed.\033[0m\n"
@@ -139,26 +139,26 @@ download() {
     # Look for explicit filename
     if [ -n "$wanted_name" ]; then
       found_path=$(fd --type f "^$(basename "$wanted_name")$" 2>/dev/null | head -n 1)
-      [ -n "$found_path" ] && printf "\033[0;36m   ✓ Found exact match: $found_path\033[0m\n"
+      [ -n "$found_path" ] && printf "\033[0;36m   ✓ Found exact match: %s\033[0m\n" "$found_path"
     fi
 
     # Search for .exe files
     if [ -z "$found_path" ]; then
       found_path=$(fd --type f '\.exe$' 2>/dev/null | head -n 1)
-      [ -n "$found_path" ] && printf "\033[0;36m   ✓ Found .exe: $found_path\033[0m\n"
+      [ -n "$found_path" ] && printf "\033[0;36m   ✓ Found .exe: %s\033[0m\n" "$found_path"
     fi
 
     # Search by base name
     if [ -z "$found_path" ] && [ -n "$wanted_name" ]; then
-      base_name=$(echo "$wanted_name" | sed 's/\..*//')
+      base_name="${wanted_name%%.*}"
       found_path=$(fd --type f "$base_name" 2>/dev/null | head -n 1)
-      [ -n "$found_path" ] && printf "\033[0;36m   ✓ Found by name: $found_path\033[0m\n"
+      [ -n "$found_path" ] && printf "\033[0;36m   ✓ Found by name: %s\033[0m\n" "$found_path"
     fi
 
     # Any file
     if [ -z "$found_path" ]; then
       found_path=$(fd --type f . 2>/dev/null | head -n 1)
-      [ -n "$found_path" ] && printf "\033[0;36m   ✓ Found fallback: $found_path\033[0m\n"
+      [ -n "$found_path" ] && printf "\033[0;36m   ✓ Found fallback: %s\033[0m\n" "$found_path"
     fi
   else
     printf "\033[0;36m   Using glob patterns for search...\033[0m\n"
@@ -166,7 +166,7 @@ download() {
     # Look for explicit file in current dir first
     if [ -f "$wanted_name" ] && [ -n "$wanted_name" ]; then
       found_path="$wanted_name"
-      printf "\033[0;36m   ✓ Found: $found_path\033[0m\n"
+      printf "\033[0;36m   ✓ Found: %s\033[0m\n" "$found_path"
     fi
 
     # Search for .exe files in current directory
@@ -174,7 +174,7 @@ download() {
       for file in *.exe; do
         if [ -f "$file" ]; then
           found_path="$file"
-          printf "\033[0;36m   ✓ Found .exe: $found_path\033[0m\n"
+          printf "\033[0;36m   ✓ Found .exe: %s\033[0m\n" "$found_path"
           break
         fi
       done
@@ -187,7 +187,7 @@ download() {
         for file in "$subdir"*.exe; do
           if [ -f "$file" ]; then
             found_path="$file"
-            printf "\033[0;36m   ✓ Found .exe in subdir: $found_path\033[0m\n"
+            printf "\033[0;36m   ✓ Found .exe in subdir: %s\033[0m\n" "$found_path"
             break 2
           fi
         done
@@ -196,11 +196,11 @@ download() {
 
     # Match wanted_name in current dir
     if [ -z "$found_path" ] && [ -n "$wanted_name" ]; then
-      base_name=$(echo "$wanted_name" | sed 's/\..*//')
+      base_name="${wanted_name%%.*}"
       for file in *"$base_name"*; do
         if [ -f "$file" ]; then
           found_path="$file"
-          printf "\033[0;36m   ✓ Found matching: $found_path\033[0m\n"
+          printf "\033[0;36m   ✓ Found matching: %s\033[0m\n" "$found_path"
           break
         fi
       done
@@ -208,13 +208,13 @@ download() {
 
     # Try subdirectories for matching name
     if [ -z "$found_path" ] && [ -n "$wanted_name" ]; then
-      base_name=$(echo "$wanted_name" | sed 's/\..*//')
+      base_name="${wanted_name%%.*}"
       for subdir in */; do
         [ -d "$subdir" ] || continue
         for file in "$subdir"*"$base_name"*; do
           if [ -f "$file" ]; then
             found_path="$file"
-            printf "\033[0;36m   ✓ Found in subdir: $found_path\033[0m\n"
+            printf "\033[0;36m   ✓ Found in subdir: %s\033[0m\n" "$found_path"
             break 2
           fi
         done
@@ -226,7 +226,7 @@ download() {
       for file in *; do
         if [ -f "$file" ]; then
           found_path="$file"
-          printf "\033[0;36m   ✓ Found fallback: $found_path\033[0m\n"
+          printf "\033[0;36m   ✓ Found fallback: %s\033[0m\n" "$found_path"
           break
         fi
       done
@@ -259,7 +259,7 @@ download() {
 
     mv "$found_path" "$target_dir/$final_name"
     chmod +x "$target_dir/$final_name"
-    printf "\033[0;32m✅ Installed to: \033[1;32m$target_dir/$final_name\033[0m\n"
+    printf "\033[0;32m✅ Installed to: \033[1;32m%s\033[0m\n" "$target_dir/$final_name"
   else
     printf "\033[0;31m❌ Could not find executable.\033[0m\n"
   fi

--- a/dotfiles/.config/shell/shell.d/44-system.sh
+++ b/dotfiles/.config/shell/shell.d/44-system.sh
@@ -13,7 +13,7 @@ fkill() {
   else
     pid=$(ps aux | fzf --header-lines=1 --no-preview --header "🔥 SELECT PROCESS TO KILL" | awk '{print $2}')
   fi
-  [ -n "$pid" ] && kill -9 "$pid" && printf "\033[0;31m💀 Killed PID: \033[1;31m$pid\033[0m\n"
+  [ -n "$pid" ] && kill -9 "$pid" && printf "\033[0;31m💀 Killed PID: \033[1;31m%s\033[0m\n" "$pid"
 }
 
 # cleanup

--- a/dotfiles/.config/shell/shell.d/45-git.sh
+++ b/dotfiles/.config/shell/shell.d/45-git.sh
@@ -13,12 +13,12 @@ command -v git >/dev/null 2>&1 || return 0
 # gcm
 # Description: Git add, commit with message.
 # Usage: gcm "message"
-gcm() { [ -n "$1" ] && git add -A && git commit -m "$1" && printf "\033[0;32m✅ Committed: \033[1;32m$1\033[0m\n"; }
+gcm() { [ -n "$1" ] && git add -A && git commit -m "$1" && printf "\033[0;32m✅ Committed: \033[1;32m%s\033[0m\n" "$1"; }
 
 # gcp
 # Description: Git add, commit, and push.
 # Usage: gcp "message"
-gcp() { [ -n "$1" ] && git add -A && git commit -m "$1" && git push && printf "\033[0;32m🚀 Pushed: \033[1;32m$1\033[0m\n"; }
+gcp() { [ -n "$1" ] && git add -A && git commit -m "$1" && git push && printf "\033[0;32m🚀 Pushed: \033[1;32m%s\033[0m\n" "$1"; }
 
 # gundo
 # Description: Soft reset (undo last commit, keep changes staged).
@@ -79,7 +79,7 @@ gcob() {
       --header "🌿 CHECKOUT BRANCH")
   if [ -n "$branch" ]; then
     git checkout "${branch#origin/}"
-    printf "\033[0;32m🌿 Switched to: \033[1;32m${branch#origin/}\033[0m\n"
+    printf "\033[0;32m🌿 Switched to: \033[1;32m%s\033[0m\n" "${branch#origin/}"
   fi
 }
 
@@ -98,7 +98,7 @@ fco() {
   local commits commit
   commits=$(git log --pretty=oneline --abbrev-commit --reverse) &&
     commit=$(echo "$commits" | fzf --tac +s +m -e --header "🕰️  CHECKOUT COMMIT" --preview 'git show --color=always {1}') &&
-    git checkout "$(echo "$commit" | sed "s/ .*//")"
+    git checkout "${commit%% *}"
 }
 
 # fshow - Git commit browser
@@ -124,7 +124,7 @@ gdf() {
     fzf --preview 'git diff --color=always -- {}' \
       --preview-window=right:70% \
       --header "Select file to open" |
-    xargs -r ${EDITOR:-vim}
+    xargs -r "${EDITOR:-vim}"
 }
 
 # gll

--- a/dotfiles/.config/yazi/init.lua
+++ b/dotfiles/.config/yazi/init.lua
@@ -1,37 +1,37 @@
-require("copy-file-contents"):setup({
-    append_char = "\n",
-    notification = true,
-})
+require("copy-file-contents"):setup {
+  append_char = "\n",
+  notification = true,
+}
 
 require("full-border"):setup {
-    -- Available values: ui.Border.PLAIN, ui.Border.ROUNDED
-    type = ui.Border.ROUNDED,
+  -- Available values: ui.Border.PLAIN, ui.Border.ROUNDED
+  type = ui.Border.ROUNDED,
 }
 
 -- require("git"):setup()
 
 require("starship"):setup()
 
-require("yaziline"):setup({
-    -- Powerline separators for maximum visual impact
-    separator_style = "curvy", -- "angly" | "curvy" | "liney" | "empty"
-    separator_open = "", -- left solid
-    separator_close = "", -- right solid
+require("yaziline"):setup {
+  -- Powerline separators for maximum visual impact
+  separator_style = "curvy", -- "angly" | "curvy" | "liney" | "empty"
+  separator_open = "", -- left solid
+  separator_close = "", -- right solid
 
-    -- Inner (thin) layer
-    separator_open_thin = "", -- left thin
-    separator_close_thin = "", -- right thin
+  -- Inner (thin) layer
+  separator_open_thin = "", -- left thin
+  separator_close_thin = "", -- right thin
 
-    -- Rounded caps
-    separator_head = "",
-    separator_tail = "",
+  -- Rounded caps
+  separator_head = "",
+  separator_tail = "",
 
-    -- Icons with Nerd Font symbols
-    select_symbol = "󰻃", -- selection icon (more visible)
-    yank_symbol = "󰆐", -- yank/copy icon
+  -- Icons with Nerd Font symbols
+  select_symbol = "󰻃", -- selection icon (more visible)
+  yank_symbol = "󰆐", -- yank/copy icon
 
-    -- Filename display settings for better context
-    filename_max_length = 40, -- increased from 24 for more info
-    filename_truncate_length = 12, -- increased from 6 for better context
-    filename_truncate_separator = "…" -- single ellipsis character
-})
+  -- Filename display settings for better context
+  filename_max_length = 40, -- increased from 24 for more info
+  filename_truncate_length = 12, -- increased from 6 for better context
+  filename_truncate_separator = "…", -- single ellipsis character
+}

--- a/misc/justfiles/verify.just
+++ b/misc/justfiles/verify.just
@@ -1,0 +1,158 @@
+# Validate dotfiles application configs. Each recipe runs the application's own
+# config check against the repo config. The required tools must be on PATH;
+# CI installs them per app via `nix profile install "$NIXPKGS#<tool>"`.
+#
+# `[no-cd]` keeps the working directory at the invocation root (repo root) so
+# `$PWD`, relative paths, and `vendir sync` resolve correctly from a submodule.
+
+[no-cd]
+[doc('Verify Hyprland config')]
+hyprland:
+    hyprland --verify-config -c "$PWD/dotfiles/.config/hypr/hyprland.lua"
+
+[no-cd]
+[doc('Validate Neovim config')]
+neovim:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    tmp_home="$(mktemp -d)"
+    trap 'rm -rf -- "$tmp_home"' EXIT
+    mkdir -p "$tmp_home/.config"
+    ln -s "$PWD/dotfiles/.config/nvim" "$tmp_home/.config/nvim"
+
+    HOME="$tmp_home" luac -p "$tmp_home/.config/nvim/init.lua"
+
+    export HOME="$tmp_home"
+    export XDG_CONFIG_HOME="$HOME/.config"
+    export XDG_DATA_HOME="$HOME/.local/share"
+    export XDG_STATE_HOME="$HOME/.local/state"
+    export XDG_CACHE_HOME="$HOME/.cache"
+
+    nvim --headless "+Lazy! sync" +qa
+    nvim_output="$tmp_home/nvim-output"
+    if ! nvim --headless +qa >"$nvim_output" 2>&1; then
+        cat "$nvim_output"
+        exit 1
+    fi
+
+[no-cd]
+[doc('Validate Helix config')]
+helix:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    tmp_home="$(mktemp -d)"
+    trap 'rm -rf -- "$tmp_home"' EXIT
+    mkdir -p "$tmp_home/.config"
+    ln -s "$PWD/dotfiles/.config/helix" "$tmp_home/.config/helix"
+    HOME="$tmp_home" XDG_CONFIG_HOME="$tmp_home/.config" hx --health all
+
+[no-cd]
+[doc('Validate Ghostty config')]
+ghostty:
+    ghostty +validate-config --config-file="$PWD/dotfiles/.config/ghostty/config"
+
+[no-cd]
+[doc('Validate WezTerm config')]
+wezterm:
+    wezterm --config-file "$PWD/dotfiles/.config/wezterm/wezterm.lua" show-keys >/dev/null
+
+[no-cd]
+[doc('Validate Alacritty config')]
+alacritty:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    vendir sync --locked
+    tmp_home="$(mktemp -d)"
+    trap 'rm -rf -- "$tmp_home"' EXIT
+    mkdir -p "$tmp_home/.config"
+    ln -s "$PWD/dotfiles/.config/alacritty" "$tmp_home/.config/alacritty"
+    HOME="$tmp_home" alacritty migrate --dry-run --config-file "$tmp_home/.config/alacritty/alacritty.toml" >/dev/null
+
+[no-cd]
+[doc('Validate Nushell config')]
+nushell:
+    nu --config dotfiles/.config/nushell/config.nu --env-config dotfiles/.config/nushell/env.nu -c "exit 0"
+
+[no-cd]
+[doc('Validate Yazi config')]
+yazi:
+    vendir sync --locked
+    YAZI_CONFIG_HOME="$PWD/dotfiles/.config/yazi" yazi --debug
+
+[no-cd]
+[doc('Validate Starship configs')]
+starship:
+    STARSHIP_CONFIG="$PWD/dotfiles/.config/starship/starship.toml" starship print-config >/dev/null
+    STARSHIP_CONFIG="$PWD/dotfiles/.config/starship/starship.tmux.toml" starship print-config >/dev/null
+    STARSHIP_CONFIG="$PWD/dotfiles/.config/starship/starship.zellij.toml" starship print-config >/dev/null
+
+[no-cd]
+[doc('Validate Zellij config')]
+zellij:
+    zellij --config "$PWD/dotfiles/.config/zellij/config.kdl" setup --dump-config >/dev/null
+
+[no-cd]
+[doc('Validate Bash config')]
+bash:
+    bash -n dotfiles/.bashrc dotfiles/.bash_profile
+    bash -n dotfiles/.config/bash/bashrc dotfiles/.config/bash/bash_profile
+    bash -n dotfiles/.config/bash/bash.d/*.bash
+    bash -n dotfiles/.config/shell/shell.d/*.sh dotfiles/.config/shell/profile.d/*.sh
+
+[no-cd]
+[doc('Validate Zsh config')]
+zsh:
+    zsh -n dotfiles/.config/zsh/.zshrc
+    zsh -n dotfiles/.config/zsh/.zprofile
+    zsh -n dotfiles/.config/zsh/zsh.d/*.zsh
+
+[no-cd]
+[doc('Validate Stow links')]
+stow:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    vendir sync --locked
+    tmp_home="$(mktemp -d)"
+    trap 'rm -rf -- "$tmp_home"' EXIT
+    mkdir -p "$tmp_home/.config"
+    stow -v --target="$tmp_home" dotfiles
+    test -L "$tmp_home/.bashrc"
+    test -L "$tmp_home/.bash_profile"
+    test -L "$tmp_home/.config/nvim"
+    test -L "$tmp_home/.config/helix"
+    test -L "$tmp_home/.config/nushell"
+    test -L "$tmp_home/.config/starship"
+    test -L "$tmp_home/.config/zellij"
+    test -L "$tmp_home/.config/yazi"
+    test -L "$tmp_home/.config/ghostty"
+    test -L "$tmp_home/.config/zsh"
+
+[no-cd]
+[doc('Validate Git config')]
+git:
+    git config --file "$PWD/dotfiles/.config/git/config" --list >/dev/null
+
+[no-cd]
+[doc('Validate PowerShell config')]
+powershell:
+    pwsh -NoProfile -NonInteractive -Command "Get-ChildItem '$PWD/dotfiles/.config/powershell/*.ps1' | ForEach-Object { \$t = \$null; \$e = \$null; [System.Management.Automation.Language.Parser]::ParseFile(\$_.FullName, [ref]\$t, [ref]\$e); if (\$e) { throw \$e } }"
+
+[no-cd]
+[doc('Validate Claude config')]
+claude:
+    CLAUDE_CONFIG_DIR="$PWD/dotfiles/.config/claude" claude doctor
+
+[no-cd]
+[doc('Validate Codex config')]
+codex:
+    CODEX_HOME="$PWD/dotfiles/.config/codex" codex doctor
+
+[no-cd]
+[doc('Validate OpenCode config')]
+opencode:
+    OPENCODE_CONFIG_DIR="$PWD/dotfiles/.config/opencode" opencode debug config --pure >/dev/null
+
+[no-cd]
+[doc('Validate Kimi config')]
+kimi:
+    KIMI_CODE_HOME="$PWD/dotfiles/.config/kimi-code" kimi doctor

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -2,10 +2,10 @@ apiVersion: vendir.k14s.io/v1alpha1
 directories:
 - contents:
   - git:
-      commitTitle: Add ganbaru themes
-      sha: 2749b407b597790e6f08b218c2bc2acdf66210a0
+      commitTitle: Add gruvbox-material soft dark theme
+      sha: 659d2e1d669cd5722f11e58c44fd45dc26a6ffcd
       tags:
-      - yaml-68-g2749b40
+      - yaml-69-g659d2e1
     path: .
   path: dotfiles/.config/alacritty/themes/themes
 - contents:
@@ -22,8 +22,8 @@ directories:
   path: dotfiles/.config/yazi/flavors/catppuccin-mocha.yazi
 - contents:
   - git:
-      commitTitle: 'chore: use the new `ya env` subcommand'
-      sha: 598cdb671401574ac27aeee257e2f3b0c80610a1
+      commitTitle: 'fix: use WebP as `magick` output format to keep image transparency...'
+      sha: 38efe09c270162f1b0dfb6020e021a5b64bdc735
     path: .
   path: dotfiles/.config/yazi/plugins/chmod.yazi
 - contents:
@@ -34,14 +34,14 @@ directories:
   path: dotfiles/.config/yazi/plugins/copy-file-contents.yazi
 - contents:
   - git:
-      commitTitle: 'chore: use the new `ya env` subcommand'
-      sha: 598cdb671401574ac27aeee257e2f3b0c80610a1
+      commitTitle: 'fix: use WebP as `magick` output format to keep image transparency...'
+      sha: 38efe09c270162f1b0dfb6020e021a5b64bdc735
     path: .
   path: dotfiles/.config/yazi/plugins/full-border.yazi
 - contents:
   - git:
-      commitTitle: 'chore: use the new `ya env` subcommand'
-      sha: 598cdb671401574ac27aeee257e2f3b0c80610a1
+      commitTitle: 'fix: use WebP as `magick` output format to keep image transparency...'
+      sha: 38efe09c270162f1b0dfb6020e021a5b64bdc735
     path: .
   path: dotfiles/.config/yazi/plugins/git.yazi
 - contents:
@@ -54,20 +54,20 @@ directories:
   path: dotfiles/.config/yazi/plugins/ouch.yazi
 - contents:
   - git:
-      commitTitle: 'chore: use the new `ya env` subcommand'
-      sha: 598cdb671401574ac27aeee257e2f3b0c80610a1
+      commitTitle: 'fix: use WebP as `magick` output format to keep image transparency...'
+      sha: 38efe09c270162f1b0dfb6020e021a5b64bdc735
     path: .
   path: dotfiles/.config/yazi/plugins/piper.yazi
 - contents:
   - git:
-      commitTitle: 'docs(readme): update thanks section'
-      sha: a83710153ab5625a64ef98d55e6ddad480a3756f
+      commitTitle: 'docs(readme): fix example for latest version'
+      sha: 159eaba5b5052bf78ff6cfbfe4e527b946818c82
     path: .
   path: dotfiles/.config/yazi/plugins/starship.yazi
 - contents:
   - git:
-      commitTitle: 'chore: use the new `ya env` subcommand'
-      sha: 598cdb671401574ac27aeee257e2f3b0c80610a1
+      commitTitle: 'fix: use WebP as `magick` output format to keep image transparency...'
+      sha: 38efe09c270162f1b0dfb6020e021a5b64bdc735
     path: .
   path: dotfiles/.config/yazi/plugins/toggle-pane.yazi
 - contents:
@@ -130,10 +130,10 @@ directories:
   path: dotfiles/.config/hypr/wallpapers/whitesur-nord
 - contents:
   - git:
-      commitTitle: update
-      sha: 5c9ffd312c7348400d49d686e6429271f035d751
+      commitTitle: Fixed firefox issues
+      sha: 3267b3dfd9b6c3e775ad9b1f3079f848fc076bf6
       tags:
-      - 2026-05-24-14-g5c9ffd3
+      - 2026-05-24-16-g3267b3d
     path: .
   path: dotfiles/.config/hypr/wallpapers/mactahoe
 kind: LockConfig

--- a/vendir.yml
+++ b/vendir.yml
@@ -14,12 +14,12 @@ directories:
           - themes/catppuccin_mocha.toml
         newRootPath: themes
 
-  - path: dotfiles/.config/tmux/plugins/tpm
-    contents:
-      - path: .
-        git:
-          url: https://github.com/tmux-plugins/tpm
-          ref: master
+  # - path: dotfiles/.config/tmux/plugins/tpm
+  #   contents:
+  #     - path: .
+  #       git:
+  #         url: https://github.com/tmux-plugins/tpm
+  #         ref: master
 
   - path: dotfiles/.config/yazi/flavors/catppuccin-latte.yazi
     contents:


### PR DESCRIPTION
- selene now lints wezterm.lua and hyprland.lua alongside nvim (with custom
  hypr/selene.toml allowing injected `hl` global)
- add WezTerm terminal config validation (wezterm show-keys headless check)
- add Git config validation (git config --list integrity check)
- add PowerShell config validation (pwsh Parser::ParseFile syntax check)
- group Stage 2 matrix by semantic category (editors, shells, terminals, etc.)
  with inline comments for clarity
- update Justfile lint recipe to include selene for wezterm/hyprland
