### PR TITLE
fix(idle): skip dim/lock/dpms when any workspace has fullscreen window

### DIFF
--- a/dotfiles/.config/hypr/hypridle.conf
+++ b/dotfiles/.config/hypr/hypridle.conf
@@ -6,17 +6,17 @@ general {
 
 listener {
   timeout = 240
-  on-timeout = brightnessctl -s set 10%
-  on-resume = brightnessctl -r
+  on-timeout = hyprctl workspaces -j | grep -q '"hasfullscreen": true' || (brightnessctl -s set 10% && touch "$XDG_RUNTIME_DIR/hypridle_dimmed")
+  on-resume = [ -f "$XDG_RUNTIME_DIR/hypridle_dimmed" ] && (brightnessctl -r && rm "$XDG_RUNTIME_DIR/hypridle_dimmed")
 }
 
 listener {
   timeout = 300
-  on-timeout = loginctl lock-session
+  on-timeout = hyprctl workspaces -j | grep -q '"hasfullscreen": true' || loginctl lock-session
 }
 
 listener {
   timeout = 600
-  on-timeout = hyprctl dispatch dpms off
+  on-timeout = hyprctl workspaces -j | grep -q '"hasfullscreen": true' || hyprctl dispatch dpms off
   on-resume = hyprctl dispatch dpms on
 }


### PR DESCRIPTION
Prevents hypridle from dimming or locking the screen during fullscreen
video playback in VLC, Firefox, or any other fullscreen application.
