### PR TITLE
feat(nvim): add vim-tmux-navigator for seamless split/pane navigation

### DIFF
--- a/dotfiles/.config/nvim/lua/core/keymaps.lua
+++ b/dotfiles/.config/nvim/lua/core/keymaps.lua
@@ -19,11 +19,8 @@ map("n", ";", ":", { desc = "enter command mode" })
 map("i", "jk", "<Esc>", { desc = "escape insert mode" })
 map("n", "<C-q>", "<cmd>q<cr>", { silent = true, desc = "close window" })
 
--- Window navigation
-map("n", "<C-h>", "<C-w>h", { desc = "window left" })
-map("n", "<C-j>", "<C-w>j", { desc = "window down" })
-map("n", "<C-k>", "<C-w>k", { desc = "window up" })
-map("n", "<C-l>", "<C-w>l", { desc = "window right" })
+-- Window navigation: <C-h/j/k/l> is handled by vim-tmux-navigator
+-- (plugin/30-tmux-navigator.lua), which also crosses into tmux panes.
 
 -- Buffer navigation
 map("n", "<Tab>", "<cmd>bnext<cr>", { desc = "next buffer" })

--- a/dotfiles/.config/nvim/nvim-pack-lock.json
+++ b/dotfiles/.config/nvim/nvim-pack-lock.json
@@ -86,6 +86,10 @@
       "rev": "31e3c38ce9b29781e4422fc0322eb0a21f4e8668",
       "src": "https://github.com/folke/todo-comments.nvim"
     },
+    "vim-tmux-navigator": {
+      "rev": "e41c431a0c7b7388ae7ba341f01a0d217eb3a432",
+      "src": "https://github.com/christoomey/vim-tmux-navigator"
+    },
     "vim-visual-multi": {
       "rev": "a6975e7c1ee157615bbc80fc25e4392f71c344d4",
       "src": "https://github.com/mg979/vim-visual-multi"

--- a/dotfiles/.config/nvim/plugin/30-tmux-navigator.lua
+++ b/dotfiles/.config/nvim/plugin/30-tmux-navigator.lua
@@ -1,0 +1,4 @@
+-- vim-tmux-navigator: seamless <C-hjkl> movement between Neovim splits and
+-- tmux panes (paired with the tmux-side snippet in tmux.conf).
+
+vim.pack.add { { src = "https://github.com/christoomey/vim-tmux-navigator" } }


### PR DESCRIPTION
Replace the plain <C-w>h/j/k/l window-nav maps with vim-tmux-navigator
(vim.pack), whose default <C-h/j/k/l> mappings cross into tmux panes
too when paired with the tmux-side is_vim snippet (added separately
in tmux.conf). Lockfile updated by vim.pack on install.
