### PR TITLE
feat(nushell): pin BUN_INSTALL to a persistent directory

### DIFF
--- a/dotfiles/.config/nushell/env.nu
+++ b/dotfiles/.config/nushell/env.nu
@@ -87,6 +87,24 @@ if ($cargo_bin | path exists) {
     }
 }
 
+$env.BUN_INSTALL = ($env.XDG_DATA_HOME | path join "bun")
+let bun_bin = ($env.BUN_INSTALL | path join "bin")
+if ($bun_bin | path exists) {
+    let current_path = (
+        if ($env.PATH | describe) == "string" {
+            $env.PATH | split row (char esep)
+        } else {
+            $env.PATH
+        }
+    )
+
+    let already_in_path = ($current_path | any {|p| $p == $bun_bin})
+
+    if not $already_in_path {
+        $env.PATH = ($current_path | prepend $bun_bin)
+    }
+}
+
 # =============================================================================
 # Editor Configuration
 # =============================================================================


### PR DESCRIPTION
Global bun-installed CLIs (kimi, codex, ...) were landing under the
default BUN_INSTALL, which falls inside the disposable cache and
disappears on cleanup. Pin it under ~/.local/share and prepend its
bin/ to PATH once. Existing globals need one manual reinstall after
this change: `bun install -g <pkg>`.
