### PR TITLE
ci: use unique concurrency group per push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:


### PR DESCRIPTION
GitHub Actions concurrency groups support only one running and one
pending run. When several commits are pushed to main in quick
succession, older pending runs were canceled with: 'Canceling since a
higher priority waiting request exists'.

Append github.sha to the concurrency group for refs/heads/main so each
push gets its own group and all main builds run. Keep canceling stale
in-progress runs for PRs to avoid wasted work.

Deploys remain serialized via the dedicated 'pages' group.
